### PR TITLE
Update Bob.js

### DIFF
--- a/Bob.js
+++ b/Bob.js
@@ -4,10 +4,10 @@ class Bob {
 
         var options={
 
-            density:1,
-            restitution:0.4,
-            isStatic:true,
-            frictionAir:1
+            isStatic:false,  
+            density:0.8,        //experiment with different values.
+            restitution:1,     
+            friction: 0
 
         }
         this.width=width;
@@ -16,7 +16,7 @@ class Bob {
         this.x=x;
         this.y=y;
 
-        this.bob=Bodies.circle(this.x,this.y,this.r,options);
+        this.bob=Bodies.circle(this.x,this.y,this.r/2 ,options);  // radius changed
         World.add(world,this.bob);
 
 


### PR DESCRIPTION
To avoid gap between the bobs in the output, radius is taken as half of it,  because circle is drawn with the radius, but the ellipse is with diameter.  

Also experiment with option values.